### PR TITLE
Load: Always prefer using the symPtr map

### DIFF
--- a/dymcode.go
+++ b/dymcode.go
@@ -340,13 +340,11 @@ func Load(code *CodeReloc, symPtr map[string]uintptr) (*CodeModule, error) {
 	var itabIndexs []int
 	var funcTypeMap = make(map[string]*int)
 	for i, sym := range code.Syms {
-		if sym.Offset == -1 {
-			if ptr, ok := symPtr[sym.Name]; ok {
-				symAddrs[i] = int(ptr)
-			} else {
-				symAddrs[i] = -1
-				strWrite(&errBuf, "unresolve external:", sym.Name, "\n")
-			}
+		if ptr, ok := symPtr[sym.Name]; ok {
+			symAddrs[i] = int(ptr)
+		} else if sym.Offset == -1 {
+			symAddrs[i] = -1
+			strWrite(&errBuf, "unresolve external:", sym.Name, "\n")
 		} else if sym.Name == TLSNAME {
 			RegTLS(symPtr, sym.Offset)
 		} else if sym.Kind == STEXT {


### PR DESCRIPTION
This pull request changes the behaviour of the usage of the symPtr map. It will now always try to use the symPtr map if a symbol is found, instead of only using it if a symbol can not be found in the binary. This fixes several issues relating to the runtime in multiple read binaries.